### PR TITLE
Add `pattern` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ Ensure value contains foo
 ```@constraint(notContains: "foo")```
 Ensure value does not contain foo
 
-#### pattern(unimplemented)
+#### pattern
 ```@constraint(pattern: "^[0-9a-zA-Z]*$")```
 Ensure value matches regex, e.g. alphanumeric
+
+> [!WARNING]
+> Unlike others, actual validation of `pattern` is not implemented. You need to implement it on your application side.
 
 ### Int/Float
 #### min

--- a/lib/graphql/constraint/directive/constraint.rb
+++ b/lib/graphql/constraint/directive/constraint.rb
@@ -12,6 +12,7 @@ module GraphQL
         description "validate GraphQL fields"
         argument :max_length, Int, required: false, description: "validate max length for String"
         argument :min_length, Int, required: false, description: "validate min length for String"
+        argument :pattern, String, required: false, description: "validate pattern for String"
         argument :max, Int, required: false, description: "validate max length for Int"
         argument :min, Int, required: false, description: "validate min length for Int"
         locations INPUT_FIELD_DEFINITION


### PR DESCRIPTION
Added `pattern` argument.

Note: Unlike the arguments handled by this `graphql-constraint-directive` gem (maxLength, minLength, etc.), validation is not performed on the graphql-ruby side. I am determined to validate regular expressions with the model on the rails app side.
